### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/operator-sdk-build.yml
+++ b/.github/workflows/operator-sdk-build.yml
@@ -9,7 +9,7 @@ jobs:
           image: "dictmm/opencast-operator"
           tag: latest
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: dictmm/opencast-operator
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore